### PR TITLE
Fix QQ image-only messages forwarding

### DIFF
--- a/ctbx/ctbx/unifiedmessage/UnifiedMessage.cpp
+++ b/ctbx/ctbx/unifiedmessage/UnifiedMessage.cpp
@@ -39,9 +39,10 @@ namespace ctbx::message {
 					it->type = "text";
 					_image_count++;
 					it->data["text"] = "[图片" + std::to_string(_image_count) + "]";
-				}
-				else
+				} else {
 					it = msg_list.erase(it);
+					_image_count++;
+				}
 			}
 			else
 				it++;

--- a/ctbx/ctbx/unifiedmessage/UnifiedMessage.h
+++ b/ctbx/ctbx/unifiedmessage/UnifiedMessage.h
@@ -44,6 +44,7 @@ namespace ctbx::message {
 		std::string _unified_card;
 		ctbx::types::User _from;
 		short _image_count;
+		bool _image_only;
 	public:
 		explicit UnifiedMessage(const cq::GroupMessageEvent&);
 		explicit UnifiedMessage(const TgBot::Message::Ptr&, const TgBot::Bot&);


### PR DESCRIPTION
Here is a bug while forwarding QQ image-only messages.

![snipaste_2018-06-11_21-28-28](https://user-images.githubusercontent.com/5895757/41234523-050aa9c6-6dbf-11e8-960e-94ad6548ef4b.png)

After fixing:

![snipaste_2018-06-11_21-34-34](https://user-images.githubusercontent.com/5895757/41234606-41c778a8-6dbf-11e8-9b27-413a0bff4ce4.png)
